### PR TITLE
make mallctl more simple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
+  - export RUST_BACKTRACE=1
   - cargo build --verbose --target $TARGET
   - cargo test --verbose --target $TARGET
   - cargo test --verbose --target $TARGET -p jemalloc-sys

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,9 +157,9 @@ mod tests {
                        Err(libc::EINVAL));
             super::mallctl_fetch(b"epoch\0", &mut epoch).unwrap();
             assert!(epoch > 0);
-            assert_eq!(super::mallctl_set(b"", &mut epoch), Err(libc::EINVAL));
-            assert_eq!(super::mallctl_set(b"epoch", &mut epoch), Err(libc::EINVAL));
-            super::mallctl_set(b"epoch\0", &mut epoch).unwrap();
+            assert_eq!(super::mallctl_set(b"", epoch), Err(libc::EINVAL));
+            assert_eq!(super::mallctl_set(b"epoch", epoch), Err(libc::EINVAL));
+            super::mallctl_set(b"epoch\0", epoch).unwrap();
         }
     }
 }


### PR DESCRIPTION
This pr tries to expose a more convenient interface for mallctl. Two methods are still marked as unsafe because the generic type T may not be the exact type what caller wants. For example, if user pass `&str` to `mallctl_set`, it will apparently cause inappropriate memory manipulation.