### PR TITLE
Upgrade libc dependency in systest to extend support to ppc64le

### DIFF
--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 jemalloc-sys = { path = "../jemalloc-sys" }
-libc = "0.1"
+libc = "0.2"
 
 [build-dependencies]
 ctest = "0.1"


### PR DESCRIPTION
The build and tests pass on ppc64le after the change, more details in https://github.com/alexcrichton/jemallocator/issues/12
