### PR TITLE
Update jemalloc

### DIFF
--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jemalloc-sys"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 links = "jemalloc"


### PR DESCRIPTION
Includes fix to fork deadlock in OS X.

I updated the -sys crate version as well.