### PR TITLE
Add bindings to all jemalloc public functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jemallocator"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jemalloc-sys"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 links = "jemalloc"

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -17,14 +17,31 @@ use libc::{c_int, c_void, size_t, c_char};
 pub const MALLOCX_ZERO: c_int = 0x40;
 
 extern "C" {
+    // Standard API
+    #[link_name = "_rjem_malloc"]
+    pub fn malloc(size: size_t) -> *mut c_void;
+    #[link_name = "_rjem_calloc"]
+    pub fn calloc(number: size_t, size: size_t) -> *mut c_void;
+    #[link_name = "_rjem_posix_memalign"]
+    pub fn posix_memalign(ptr: *mut *mut c_void, alignment: size_t, size: size_t) -> c_int;
+    #[link_name = "_rjem_aligned_alloc"]
+    pub fn aligned_alloc(alignment: size_t, size: size_t) -> *mut c_void;
+    #[link_name = "_rjem_realloc"]
+    pub fn realloc(ptr: *mut c_void, size: size_t) -> *mut c_void;
+    #[link_name = "_rjem_free"]
+    pub fn free(ptr: *mut c_void);
+
+    // Non-standard API
     #[link_name = "_rjem_mallocx"]
     pub fn mallocx(size: size_t, flags: c_int) -> *mut c_void;
-    #[link_name = "_rjem_calloc"]
-    pub fn calloc(num: size_t, size: size_t) -> *mut c_void;
     #[link_name = "_rjem_rallocx"]
     pub fn rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
     #[link_name = "_rjem_xallocx"]
     pub fn xallocx(ptr: *mut c_void, size: size_t, extra: size_t, flags: c_int) -> size_t;
+    #[link_name = "_rjem_sallocx"]
+    pub fn sallocx(ptr: *const c_void, flags: c_int) -> size_t;
+    #[link_name = "_rjem_dallocx"]
+    pub fn dallocx(ptr: *mut c_void, flags: c_int);
     #[link_name = "_rjem_sdallocx"]
     pub fn sdallocx(ptr: *mut c_void, size: size_t, flags: c_int);
     #[link_name = "_rjem_nallocx"]

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -20,7 +20,7 @@ extern "C" {
     #[link_name = "_rjem_mallocx"]
     pub fn mallocx(size: size_t, flags: c_int) -> *mut c_void;
     #[link_name = "_rjem_calloc"]
-    pub fn calloc(size: size_t, flags: size_t) -> *mut c_void;
+    pub fn calloc(num: size_t, size: size_t) -> *mut c_void;
     #[link_name = "_rjem_rallocx"]
     pub fn rallocx(ptr: *mut c_void, size: size_t, flags: c_int) -> *mut c_void;
     #[link_name = "_rjem_xallocx"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![feature(allocator_api)]
 #![deny(missing_docs)]
 
-extern crate jemalloc_sys as ffi;
+pub extern crate jemalloc_sys as ffi;
 extern crate libc;
 
 use std::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ unsafe impl<'a> Alloc for &'a Jemalloc {
         -> Result<*mut u8, AllocErr>
     {
         let ptr = if layout.align() <= MIN_ALIGN {
-            ffi::calloc(layout.size(), 1)
+            ffi::calloc(1, layout.size())
         } else {
             let flags = align_to_flags(layout.align()) | ffi::MALLOCX_ZERO;
             ffi::mallocx(layout.size(), flags)

--- a/tests/smoke_ffi.rs
+++ b/tests/smoke_ffi.rs
@@ -1,0 +1,18 @@
+#![feature(global_allocator)]
+
+extern crate jemallocator;
+extern crate jemalloc_sys;
+
+// Work around https://github.com/alexcrichton/jemallocator/issues/19
+#[global_allocator]
+static A: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+#[test]
+fn smoke() {
+    unsafe {
+        let ptr = jemalloc_sys::malloc(4);
+        *(ptr as *mut u32) = 0xDECADE;
+        assert_eq!(*(ptr as *mut u32), 0xDECADE);
+        jemalloc_sys::free(ptr);
+    }
+}


### PR DESCRIPTION
That is, those documented in http://jemalloc.net/jemalloc.3.html

For example `malloc` and `free` can be useful when implementing callbacks for a C library that doesn’t provide a size when deallocating: https://www.freetype.org/freetype2/docs/reference/ft2-system_interface.html