### PR TITLE
Make malloc_stats_print’s argument nullable.

### DIFF
--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -70,7 +70,7 @@ extern "C" {
 
     // stats
     #[link_name = "_rjem_malloc_stats_print"]
-    pub fn malloc_stats_print(write_cb: extern "C" fn(*mut c_void, *const c_char),
+    pub fn malloc_stats_print(write_cb: Option<unsafe extern "C" fn(*mut c_void, *const c_char)>,
                               cbopaque: *mut c_void,
                               opts: *const c_char);
 }

--- a/tests/ffi.rs
+++ b/tests/ffi.rs
@@ -80,7 +80,7 @@ fn test_stats() {
 
     let mut ctx = PrintCtx { called_times: 0 };
     unsafe {
-        ffi::malloc_stats_print(write_cb, &mut ctx as *mut _ as *mut c_void, ptr::null());
+        ffi::malloc_stats_print(Some(write_cb), &mut ctx as *mut _ as *mut c_void, ptr::null());
     }
     assert_ne!(ctx.called_times,
                0,


### PR DESCRIPTION
http://jemalloc.net/jemalloc.3.html
> The malloc_stats_print() function writes summary statistics via the write_cb callback function pointer and cbopaque data passed to write_cb, or malloc_message() **if write_cb is NULL**.