### PR TITLE
Don’t assume MIN_ALIGN for small sizes

### DIFF
--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1,8 +1,9 @@
-#![feature(global_allocator)]
+#![feature(global_allocator, allocator_api)]
 
 extern crate jemallocator;
 
 use jemallocator::Jemalloc;
+use std::heap::{Alloc, Layout};
 
 #[global_allocator]
 static A: Jemalloc = Jemalloc;
@@ -11,4 +12,25 @@ static A: Jemalloc = Jemalloc;
 fn smoke() {
     let mut a = Vec::new();
     a.push(3);
+}
+
+/// https://github.com/rust-lang/rust/issues/45955
+#[test]
+fn overaligned() {
+    let size = 8;
+    let align = 16; // greater than size
+    let iterations = 100;
+    unsafe {
+        let pointers: Vec<_> = (0..iterations).map(|_| {
+            Jemalloc.alloc(Layout::from_size_align(size, align).unwrap()).unwrap()
+        }).collect();
+        for &ptr in &pointers {
+            assert_eq!((ptr as usize) % align, 0, "Got a pointer less aligned than requested")
+        }
+
+        // Clean up
+        for &ptr in &pointers {
+            Jemalloc.dealloc(ptr, Layout::from_size_align(size, align).unwrap())
+        }
+    }
 }


### PR DESCRIPTION
Same as https://github.com/rust-lang/rust/pull/46117

See also discussion of jemalloc’s behavior at https://github.com/jemalloc/jemalloc/issues/1072