### PR TITLE
[bugfix] jemalloc i686-apple-darwin build

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -45,7 +45,9 @@ fn main() {
                    .replace("\\", "/"))
        .current_dir(&build_dir)
        .env("CC", compiler.path())
-       .env("CFLAGS", cflags);
+       .env("CFLAGS", cflags.clone())
+       .env("CPPFLAGS", cflags.clone())
+       .arg("--disable-cxx") ;
 
     if target.contains("ios") {
         cmd.arg("--disable-tls");


### PR DESCRIPTION
The PR #34 was merged with a broken `i686-apple-darwin` build. This PR fixes that.