### PR TITLE
 Upgrade to rustc 1.27.0-nightly (7f3444e1b 2018-04-26) 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jemallocator"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ extern crate libc;
 
 use std::mem;
 use std::ptr::{self, NonNull};
-use std::heap::{GlobalAlloc, Alloc, Layout, Opaque, Excess, CannotReallocInPlace, AllocErr, System};
+use std::heap::{GlobalAlloc, Alloc, Layout, Opaque, Excess, CannotReallocInPlace, AllocErr};
 
 use libc::{c_int, c_void};
 
@@ -100,11 +100,6 @@ unsafe impl GlobalAlloc for Jemalloc {
         let ptr = ffi::rallocx(ptr as *mut c_void, new_size, flags);
         ptr as *mut Opaque
     }
-
-    #[inline]
-    fn oom(&self) -> ! {
-        System.oom()
-    }
 }
 
 unsafe impl Alloc for Jemalloc {
@@ -156,11 +151,6 @@ unsafe impl Alloc for Jemalloc {
         } else {
             Err(AllocErr)
         }
-    }
-
-    #[inline]
-    fn oom(&mut self) -> ! {
-        System.oom()
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,14 @@
 
 #![feature(allocator_api, nonnull_cast)]
 #![deny(missing_docs)]
+#![no_std]
 
 extern crate jemalloc_sys;
 extern crate libc;
 
-use std::mem;
-use std::ptr::{self, NonNull};
-use std::heap::{GlobalAlloc, Alloc, Layout, Opaque, Excess, CannotReallocInPlace, AllocErr};
+use core::mem;
+use core::ptr::{self, NonNull};
+use core::heap::{GlobalAlloc, Alloc, Layout, Opaque, Excess, CannotReallocInPlace, AllocErr};
 
 use libc::{c_int, c_void};
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/50144 removed `oom` trait methods.