### PR TITLE
Fix bg_thread feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 members = ["systest"]
 
 [dependencies]
-jemalloc-sys = { path = "jemalloc-sys", version = "0.1.6" }
+jemalloc-sys = { path = "jemalloc-sys", version = "0.1.6", default-features = false }
 libc = "0.2.8"
 
 [features]

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -41,7 +41,7 @@ fn main() {
     let src_dir = env::current_dir().expect("failed to get current directory");
     println!("SRC_DIR={:?}", src_dir);
 
-    let disable_bg_thread = !env::var("CARGO_FEATURE_bg_thread").is_ok();
+    let disable_bg_thread = !env::var("CARGO_FEATURE_BG_THREAD").is_ok();
 
     let unsupported_targets = [
         "rumprun",


### PR DESCRIPTION
background threads were previously always disabled since cargo upper
cases feature names. jemallocator also enabled default features on
jemalloc-sys.