### PR TITLE
Set a custom prefix for jemalloc internal symbols

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -186,6 +186,7 @@ fn main() {
 
     if use_prefix {
         cmd.arg("--with-jemalloc-prefix=_rjem_");
+        cmd.arg("--with-private-namespace=_rjem_");
         println!("cargo:rustc-cfg=prefixed");
     }
 


### PR DESCRIPTION
They otherwise conflict with the same symbols pulled in via the jemalloc
rustc provides if a custom global allocator isn't set.

Closes #51