### PR TITLE
Prefix private symbols unconditionally

### DIFF
--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -186,9 +186,10 @@ fn main() {
 
     if use_prefix {
         cmd.arg("--with-jemalloc-prefix=_rjem_");
-        cmd.arg("--with-private-namespace=_rjem_");
         println!("cargo:rustc-cfg=prefixed");
     }
+
+    cmd.arg("--with-private-namespace=_rjem_");
 
     if env::var_os("CARGO_FEATURE_DEBUG").is_some() {
         println!("CARGO_FEATURE_DEBUG set");


### PR DESCRIPTION
The point of the `no_prefix` flag it to override libc symbols like `malloc`, it shouldn’t affect jemalloc’s internal APIs.

Fixes https://github.com/alexcrichton/jemallocator/pull/53#issuecomment-399782316.