### PR TITLE
fix shrink_in_place implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,12 +180,9 @@ unsafe impl Alloc for Jemalloc {
                               layout: Layout,
                               new_size: usize) -> Result<(), CannotReallocInPlace> {
         let flags = layout_to_flags(layout.align(), new_size);
-        let size = ffi::xallocx(ptr.cast().as_ptr(), new_size, 0, flags);
-        if size >= new_size {
-            Err(CannotReallocInPlace)
-        } else {
-            Ok(())
-        }
+        let shrunk_size = ffi::xallocx(ptr.cast().as_ptr(), new_size, 0, flags);
+        debug_assert!(shrunk_size >= new_size);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug in the `shrink_in_place` implementation: if the size of the shrunk memory block is greater or equal than the desired size it currently errors, but this should actually be a success, and the else branch cannot ever happen unless there is a bug in jemalloc.

That is, the user asks for a desired size that is smaller than the original allocation size, and we are allowed to return a memory block that is larger than that. 