### PR TITLE
Make some function pointers nullable and test writing to malloc_conf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jemallocator"
-version = "0.1.9"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -20,7 +20,7 @@ bench = false
 members = ["systest"]
 
 [dependencies]
-jemalloc-sys = { path = "jemalloc-sys", version = "0.1.7", default-features = false }
+jemalloc-sys = { path = "jemalloc-sys", version = "0.2.0", default-features = false }
 libc = "0.2.8"
 
 [features]

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jemalloc-sys"
-version = "0.1.8"
+version = "0.2.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 build = "build.rs"
 links = "jemalloc"

--- a/jemalloc-sys/src/lib.rs
+++ b/jemalloc-sys/src/lib.rs
@@ -528,7 +528,7 @@ extern "C" {
     /// counters that track thread cache operations.
     #[cfg_attr(prefixed, link_name = "_rjem_malloc_stats_print")]
     pub fn malloc_stats_print(
-        write_cb: unsafe extern "C" fn(*mut c_void, *const c_char),
+        write_cb: Option<unsafe extern "C" fn(*mut c_void, *const c_char)>,
         cbopaque: *mut c_void,
         opts: *const c_char,
     );
@@ -544,7 +544,8 @@ extern "C" {
     /// Please note that doing anything which tries to allocate memory in this
     /// function is likely to result in a crash or deadlock.
     #[cfg_attr(prefixed, link_name = "_rjem_malloc_message")]
-    pub static mut malloc_message: unsafe extern "C" fn(cbopaque: *mut c_void, s: *const c_char);
+    pub static mut malloc_message:
+        Option<unsafe extern "C" fn(cbopaque: *mut c_void, s: *const c_char)>;
 
     /// Compile-time string of configuration options.
     ///

--- a/jemalloc-sys/tests/malloc_conf_set.rs
+++ b/jemalloc-sys/tests/malloc_conf_set.rs
@@ -11,7 +11,7 @@ union U {
 #[cfg_attr(not(prefixed), no_mangle)]
 pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
     U {
-        x: &b"abort:true\0"[0],
+        x: &b"stats_print_opts:mdal\0"[0],
     }
     .y
 });
@@ -20,5 +20,25 @@ pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
 fn malloc_conf_set() {
     unsafe {
         assert_eq!(jemalloc_sys::malloc_conf, malloc_conf);
+
+        let mut ptr: *const libc::c_char = std::ptr::null();
+        let mut ptr_len: libc::size_t = std::mem::size_of::<*const libc::c_char>() as libc::size_t;
+        let r = jemalloc_sys::mallctl(
+            &b"opt.stats_print_opts\0"[0] as *const _ as *const libc::c_char,
+            &mut ptr as *mut *const _ as *mut libc::c_void,
+            &mut ptr_len as *mut _,
+            std::ptr::null_mut(),
+            0,
+        );
+        assert_eq!(r, 0);
+        assert!(!ptr.is_null());
+
+        let s = std::ffi::CStr::from_ptr(ptr).to_string_lossy().into_owned();
+        assert!(
+            s.contains("mdal"),
+            "opt.stats_print_opts: \"{}\" (len = {})",
+            s,
+            s.len()
+        );
     }
 }

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -9,4 +9,4 @@ jemalloc-sys = { path = "../jemalloc-sys" }
 libc = "0.2"
 
 [build-dependencies]
-ctest = "^0.2.5"
+ctest = "^0.2.6"

--- a/tests/ffi.rs
+++ b/tests/ffi.rs
@@ -82,7 +82,11 @@ fn test_stats() {
 
     let mut ctx = PrintCtx { called_times: 0 };
     unsafe {
-        ffi::malloc_stats_print(write_cb, &mut ctx as *mut _ as *mut c_void, ptr::null());
+        ffi::malloc_stats_print(
+            Some(write_cb),
+            &mut ctx as *mut _ as *mut c_void,
+            ptr::null(),
+        );
     }
     assert_ne!(
         ctx.called_times, 0,


### PR DESCRIPTION
It turns out that `malloc_message` is null by default, so it has to be updated to an `Option<fn>`. That's an API breaking change, so i'm updating `malloc_stats_print` here as well (#22). 

The background thread feature renames are going to be backwards incompatible as well, so I'll wait for those to do a new release.  I'm bumping the version to 0.2 (as agreed in #22) so that we don't accidentally make a backwards incompatible 0.1 release.