### PR TITLE
Background threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
       addons: *gcc_multilib
       rust: stable  
     - name: "i686-unknown-linux-musl"
-      env: TARGET=i686-unknown-linux-musl
+      env: TARGET=i686-unknown-linux-musl NOBGT=1
     - name: "mips-unknown-linux-gnu"
       env: TARGET=mips-unknown-linux-gnu
     - name: "mips64-unknown-linux-gnuabi64"
@@ -57,7 +57,7 @@ matrix:
       rust: stable
       install: true
     - name: "x86_64-unknown-linux-musl"
-      env: TARGET=x86_64-unknown-linux-musl
+      env: TARGET=x86_64-unknown-linux-musl NOBGT=1
 
     # Android
     - name: "aarch64-linux-android"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,10 @@ libc = "0.2.8"
 
 [features]
 alloc_trait = []
-default = ["bg_thread"]
+default = ["background_threads_runtime_support"]
 profiling = ["jemalloc-sys/profiling"]
 debug = ["jemalloc-sys/debug"]
 stats = ["jemalloc-sys/stats"]
-bg_thread = ["jemalloc-sys/bg_thread"]
+background_threads_runtime_support = ["jemalloc-sys/background_threads_runtime_support"]
+background_threads = ["jemalloc-sys/background_threads"]
 unprefixed_malloc_on_supported_platforms = ["jemalloc-sys/unprefixed_malloc_on_supported_platforms"]

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -31,15 +31,15 @@ ${CARGO_CMD} test -vv --target "${TARGET}" --features debug
 ${CARGO_CMD} test -vv --target "${TARGET}" --features stats
 ${CARGO_CMD} test -vv --target "${TARGET}" --features 'debug profiling'
 ${CARGO_CMD} test -vv --target "${TARGET}" --features unprefixed_malloc_on_supported_platforms
-${CARGO_CMD} test -vv --target $TARGET --no-default-features
-${CARGO_CMD} test -vv --target $TARGET --no-default-features \
+${CARGO_CMD} test -vv --target "${TARGET}" --no-default-features
+${CARGO_CMD} test -vv --target "${TARGET}" --no-default-features \
              --features background_threads_runtime_support
 
 if [ "${NOBGT}" = "1" ]
 then
     echo "enabling background threads by default at run-time is not tested"
 else
-    ${CARGO_CMD} test -vv --target $TARGET --features background_threads
+    ${CARGO_CMD} test -vv --target "${TARGET}" --features background_threads
 fi
 
 ${CARGO_CMD} test -vv --target "${TARGET}" --release

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -31,6 +31,17 @@ ${CARGO_CMD} test -vv --target "${TARGET}" --features debug
 ${CARGO_CMD} test -vv --target "${TARGET}" --features stats
 ${CARGO_CMD} test -vv --target "${TARGET}" --features 'debug profiling'
 ${CARGO_CMD} test -vv --target "${TARGET}" --features unprefixed_malloc_on_supported_platforms
+${CARGO_CMD} test -vv --target $TARGET --no-default-features
+${CARGO_CMD} test -vv --target $TARGET --no-default-features \
+             --features background_threads_runtime_support
+
+if [ "${NOBGT}" = "1" ]
+then
+    echo "enabling background threads by default at run-time is not tested"
+else
+    ${CARGO_CMD} test -vv --target $TARGET --features background_threads
+fi
+
 ${CARGO_CMD} test -vv --target "${TARGET}" --release
 ${CARGO_CMD} test -vv --target "${TARGET}" -p jemalloc-sys
 ${CARGO_CMD} test -vv --target "${TARGET}" -p jemalloc-sys --features unprefixed_malloc_on_supported_platforms

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -26,9 +26,10 @@ cc = "^1.0.13"
 fs_extra = "^1.1"
 
 [features]
-default = ["bg_thread"]
+default = ["background_threads_runtime_support"]
 profiling = []
 debug = []
-bg_thread = []
+background_threads_runtime_support = []
+background_threads = [ "background_threads_runtime_support" ]
 stats = []
 unprefixed_malloc_on_supported_platforms = []

--- a/jemalloc-sys/build.rs
+++ b/jemalloc-sys/build.rs
@@ -249,7 +249,7 @@ fn main() {
             || target.contains("musl")
             || target.contains("darwin"))
     {
-        println!("Unprefixed malloc() requested on unsupported platform");
+        println!("cargo:warning=\"Unprefixed malloc() requested on unsupported platform\"");
         use_prefix = true;
     }
 

--- a/jemalloc-sys/readme.md
+++ b/jemalloc-sys/readme.md
@@ -37,16 +37,20 @@ This crate provides following cargo feature flags:
   * `gcc intrinsics` (unless --disable-prof-gcc)
 
 * `stats` (configure `jemalloc` with `--enable-stats`): Enable statistics
-  gathering functionality. See the `jemalloc`'s "opt.stats_print" option documentation for
-  usage details.
+  gathering functionality. See the `jemalloc`'s "`opt.stats_print`" option
+  documentation for usage details.
   
 * `debug` (configure `jemalloc` with `--enable-debug`): Enable assertions and
   validation code. This incurs a substantial performance hit, but is very useful
   during application development.
   
-* `bg_thread` (enabled by default - configure `jemalloc` with
-  `--with-malloc-conf=background_thread:false`): When disabled, disable internal
-  background worker threads. When set to true, background threads are created on
+* `background_threads_runtime_support` (enabled by default): enables
+  background-threads run-time support when building `jemalloc-sys` on some POSIX
+  targets supported by `jemalloc`. Background threads are disabled at run-time
+  by default. This option allows dynamically enabling them at run-time.
+
+* `background_threads` (disabled by default): enables background threads by
+  default at run-time. When set to true, background threads are created on
   demand (the number of background threads will be no more than the number of
   CPUs or active arenas). Threads run periodically, and handle purging
   asynchronously. When switching off, background threads are terminated

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ pub unsafe fn usable_size<T>(ptr: *const T) -> usize {
 ///
 /// Please note that if you want to fetch a string, use char* instead of &str or
 /// cstring.
-pub unsafe fn mallctl_fetch<T>(name: &[u8], t: &mut T) -> Result<(), i32> {
+pub unsafe fn mallctl_fetch<T>(name: &[u8], t: &mut T) -> Result<(), libc::c_int> {
     // make sure name is a valid c string.
     if name.is_empty() || *name.last().unwrap() != 0 {
         return Err(libc::EINVAL);
@@ -231,6 +231,7 @@ pub unsafe fn mallctl_fetch<T>(name: &[u8], t: &mut T) -> Result<(), i32> {
         ptr::null_mut(),
         0,
     );
+
     if code != 0 {
         return Err(code);
     }
@@ -241,7 +242,7 @@ pub unsafe fn mallctl_fetch<T>(name: &[u8], t: &mut T) -> Result<(), i32> {
 ///
 /// Please note that if you want to set a string, use char* instead of &str or
 /// cstring.
-pub unsafe fn mallctl_set<T>(name: &[u8], mut t: T) -> Result<(), i32> {
+pub unsafe fn mallctl_set<T>(name: &[u8], mut t: T) -> Result<(), libc::c_int> {
     // make sure name is a valid c string.
     if name.is_empty() || *name.last().unwrap() != 0 {
         return Err(libc::EINVAL);

--- a/tests/background_thread_defaults.rs
+++ b/tests/background_thread_defaults.rs
@@ -1,0 +1,35 @@
+//! Test background threads run-time default settings.
+extern crate jemallocator;
+extern crate libc;
+
+use jemallocator::Jemalloc;
+
+#[global_allocator]
+static A: Jemalloc = Jemalloc;
+
+// Returns true if background threads are enabled.
+fn background_threads() -> bool {
+    unsafe {
+        let mut v: bool = false;
+        jemallocator::mallctl_fetch(b"opt.background_thread\0", &mut v).unwrap();
+        v
+    }
+}
+
+#[test]
+fn background_threads_runtime_defaults() {
+    if !cfg!(feature = "background_threads_runtime_support") {
+        // If the crate was compiled without background thread support,
+        // then background threads are always disabled at run-time by default:
+        assert_eq!(background_threads(), false);
+        return;
+    }
+
+    if cfg!(feature = "background_threads") {
+        // The crate was compiled with background-threads enabled by default:
+        assert_eq!(background_threads(), true);
+    } else {
+        // The crate was compiled with background-threads disabled by default:
+        assert_eq!(background_threads(), false);
+    }
+}

--- a/tests/background_thread_enabled.rs
+++ b/tests/background_thread_enabled.rs
@@ -1,0 +1,43 @@
+//! Test enabling / disabling background threads at run-time if the
+//! library was compiled with background thread run-time support.
+#![cfg(feature = "background_threads_runtime_support")]
+#![cfg(not(feature = "unprefixed_malloc_on_supported_platforms"))]
+
+extern crate jemallocator;
+extern crate libc;
+
+use jemallocator::Jemalloc;
+
+#[global_allocator]
+static A: Jemalloc = Jemalloc;
+
+union U {
+    x: &'static u8,
+    y: &'static libc::c_char,
+}
+
+// Even if background threads are not enabled at run-time by default
+// at configuration time, this enables them.
+#[allow(non_upper_case_globals)]
+#[export_name = "_rjem_malloc_conf"]
+pub static malloc_conf: Option<&'static libc::c_char> = Some(unsafe {
+    U {
+        x: &b"background_thread:true\0"[0],
+    }
+    .y
+});
+
+// Returns true if background threads are enabled.
+fn background_threads() -> bool {
+    unsafe {
+        let mut v: bool = false;
+        jemallocator::mallctl_fetch(b"opt.background_thread\0", &mut v).unwrap();
+        v
+    }
+}
+
+#[test]
+fn background_threads_enabled() {
+    // Background threads are unconditionally enabled at run-time by default.
+    assert_eq!(background_threads(), true);
+}

--- a/tests/background_thread_enabled.rs
+++ b/tests/background_thread_enabled.rs
@@ -2,6 +2,7 @@
 //! library was compiled with background thread run-time support.
 #![cfg(feature = "background_threads_runtime_support")]
 #![cfg(not(feature = "unprefixed_malloc_on_supported_platforms"))]
+#![cfg(not(target_env = "musl"))]
 
 extern crate jemallocator;
 extern crate libc;


### PR DESCRIPTION
* rename `bg_thread` feature to `background_threads_runtime_support`
* add `background_threads` option to enable background threads at run-time
* [breaking change]: use a newtype for `mallctl` errors
* warn if unprefixed jemalloc requested in an unsupported platform