### PR TITLE
Add jemallocator-global crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,14 @@ documentation = "https://docs.rs/jemallocator"
 description = """
 A Rust allocator backed by jemalloc
 """
+edition = "2015"
 
 [lib]
 test = false
 bench = false
 
 [workspace]
-members = ["systest"]
+members = ["systest", "jemallocator-global" ]
 
 [dependencies]
 jemalloc-sys = { path = "jemalloc-sys", version = "0.2.0", default-features = false }
@@ -27,8 +28,8 @@ libc = { version = "^0.2.8", default-features = false }
 paste = "0.1"
 
 [features]
-alloc_trait = []
 default = ["background_threads_runtime_support"]
+alloc_trait = []
 profiling = ["jemalloc-sys/profiling"]
 debug = ["jemalloc-sys/debug"]
 stats = ["jemalloc-sys/stats"]

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -76,7 +76,8 @@ ${CARGO_CMD} test -vv --target "${TARGET}" --features profiling
 ${CARGO_CMD} test -vv --target "${TARGET}" --features debug
 ${CARGO_CMD} test -vv --target "${TARGET}" --features stats
 ${CARGO_CMD} test -vv --target "${TARGET}" --features 'debug profiling'
-${CARGO_CMD} test -vv --target "${TARGET}" --features unprefixed_malloc_on_supported_platforms
+${CARGO_CMD} test -vv --target "${TARGET}" \
+             --features unprefixed_malloc_on_supported_platforms
 ${CARGO_CMD} test -vv --target "${TARGET}" --no-default-features
 ${CARGO_CMD} test -vv --target "${TARGET}" --no-default-features \
              --features background_threads_runtime_support
@@ -89,9 +90,16 @@ else
 fi
 
 ${CARGO_CMD} test -vv --target "${TARGET}" --release
-${CARGO_CMD} test -vv --target "${TARGET}" -p jemalloc-sys
-${CARGO_CMD} test -vv --target "${TARGET}" -p jemalloc-sys --features unprefixed_malloc_on_supported_platforms
+${CARGO_CMD} test -vv --target "${TARGET}" --manifest-path jemalloc-sys/Cargo.toml
+${CARGO_CMD} test -vv --target "${TARGET}" \
+             --manifest-path jemalloc-sys/Cargo.toml \
+             --features unprefixed_malloc_on_supported_platforms
 ${CARGO_CMD} test -vv --target "${TARGET}" -p systest
+${CARGO_CMD} test -vv --target "${TARGET}" \
+             --manifest-path jemallocator-global/Cargo.toml
+${CARGO_CMD} test -vv --target "${TARGET}" \
+             --manifest-path jemallocator-global/Cargo.toml \
+             --features force_global_jemalloc
 
 if [ "${TRAVIS_RUST_VERSION}" = "nightly"  ]
 then

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["allocator"]
 description = """
 Rust FFI bindings to jemalloc
 """
+edition = "2015"
 
 [lib]
 test = false

--- a/jemalloc-sys/readme.md
+++ b/jemalloc-sys/readme.md
@@ -141,5 +141,5 @@ at your option.
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in jemallocator by you, as defined in the Apache-2.0 license, shall be
-dual licensed as above, without any additional terms or conditions.
+for inclusion in `jemalloc-sys` by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.

--- a/jemallocator-global/Cargo.toml
+++ b/jemallocator-global/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "jemallocator-global"
+version = "0.3.0"
+authors = ["Gonzalo Brito Gadeschi <gonzalobg88@gmail.com>"]
+edition = "2015"
+license = "MIT/Apache-2.0"
+readme = "README.md"
+keywords = ["allocator", "jemalloc"]
+categories = ["memory-management", "api-bindings"]
+repository = "https://github.com/alexcrichton/jemallocator"
+homepage = "https://github.com/alexcrichton/jemallocator"
+documentation = "https://docs.rs/jemallocator-global"
+description = """
+Sets `jemalloc` as the `#[global_allocator]`
+"""
+
+ [badges]
+appveyor = { repository = "alexcrichton/jemallocator" }
+travis-ci = { repository = "alexcrichton/jemallocator" }
+codecov = { repository = "alexcrichton/jemallocator" }
+is-it-maintained-issue-resolution = { repository = "alexcrichton/jemallocator" }
+is-it-maintained-open-issues = { repository = "alexcrichton/jemallocator" }
+maintenance = { status = "actively-developed" }
+
+[dependencies]
+jemallocator = { optional = true, path = "..", version = "0.2.0" }
+cfg-if = "0.1"
+
+[features]
+default = []
+# Unconditionally sets jemalloc as the global allocator:
+force_global_jemalloc = [ "jemallocator" ]
+
+# To enable `jemalloc` as the `#[global_allocator]` by default
+# for a particular target, white-list the target explicitly here:
+
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))'.dependencies]
+jemallocator = { optional = false, path = ".." }
+
+# FIXME: https://github.com/alexcrichton/jemallocator/issues/91
+# [target.'cfg(target_os = "windows")'.dependencies]
+# jemallocator = { path = ".." }
+
+# `jemalloc` is known not to work on - see `jemalloc-sys/build.rs`.
+# - rumprun
+# - bitrig
+# - redox
+# - fuchsia
+# - emscripten
+# - wasm32
+

--- a/jemallocator-global/LICENSE-APACHE
+++ b/jemallocator-global/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/jemallocator-global/LICENSE-MIT
+++ b/jemallocator-global/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/jemallocator-global/README.md
+++ b/jemallocator-global/README.md
@@ -1,0 +1,60 @@
+# jemallocator-global
+
+[![Travis-CI Status]][travis] [![Appveyor Status]][appveyor] [![Latest Version]][crates.io] [![docs]][docs.rs]
+
+> Sets `jemalloc` as the `#[global allocator]` on targets that support it.
+
+## Documentation / usage
+
+Add it as a dependency:
+
+```toml
+# Cargo.toml
+[dependencies]
+jemallocator-global = "0.3.0"
+```
+
+and `jemalloc` will be used as the `#[global_allocator]` on targets that support
+it.
+
+## Cargo features
+
+* `force_global_jemalloc` (disabled by default): unconditionally sets `jemalloc`
+  as the `#[global_allocator]`.
+
+[`jemallocator`]: https://github.com/alexcrichton/jemallocator/
+
+## Platform support 
+
+See [`jemallocator`]'s platform support.
+
+## Documentation
+
+For more information check out the [`jemallocator`] crate.
+
+## License
+
+This project is licensed under either of
+
+ * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+   http://www.apache.org/licenses/LICENSE-2.0)
+ * MIT license ([LICENSE-MIT](LICENSE-MIT) or
+   http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in `jemallocator-global` by you, as defined in the Apache-2.0 license,
+shall be dual licensed as above, without any additional terms or conditions.
+
+[travis]: https://travis-ci.org/alexcrichton/jemallocator
+[Travis-CI Status]: https://travis-ci.org/alexcrichton/jemallocator.svg?branch=master
+[appveyor]: https://ci.appveyor.com/project/alexcrichton/jemallocator/branch/master
+[Appveyor Status]: https://ci.appveyor.com/api/projects/status/github/alexcrichton/jemallocator?branch=master&svg=true
+[Latest Version]: https://img.shields.io/crates/v/jemallocator-global.svg
+[crates.io]: https://crates.io/crates/jemallocator-global
+[docs]: https://docs.rs/jemallocator-global/badge.svg
+[docs.rs]: https://docs.rs/jemallocator-global/
+

--- a/jemallocator-global/src/lib.rs
+++ b/jemallocator-global/src/lib.rs
@@ -1,0 +1,69 @@
+//! Sets `jemalloc` as the `#[global_allocator]` on targets that support it.
+//!
+//! Just add `jemallocator-global` as a dependency:
+//!
+//! ```toml
+//! # Cargo.toml
+//! [dependencies]
+//! jemallocator-global = "0.3.0"
+//! ```
+//!
+//! and `jemalloc` will be used as the `#[global_allocator]` on targets that
+//! support it.
+//!
+//! To unconditionally set `jemalloc` as the `#[global_allocator]` enable the
+//! `force_global_jemalloc` cargo feature.
+
+#[macro_use]
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(any(
+        feature = "force_global_jemalloc",
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))] {
+        extern crate jemallocator;
+
+        /// Sets `jemalloc` as the `#[global_allocator]`.
+        #[global_allocator]
+        pub static JEMALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Test that jemallocator-global is enabled automatically in those targets in
+    // which it should be enabled:
+
+    macro_rules! check {
+        () => {
+            #[test]
+            fn foo() {
+                let _ = super::JEMALLOC;
+            }
+        };
+        ($os_name:tt) => {
+            #[cfg(target_os = $os_name)]
+            check!();
+        };
+        ($($os_name:tt),*) => {
+            $(check!($os_name);)*
+        }
+    }
+
+    // If the `force_global_jemalloc` feature is enabled, then it
+    // should always be set as the global allocator:
+    #[cfg(feature = "force_global_jemalloc")]
+    check!();
+
+    // If the `force_global_jemalloc` feature is not enabled, then in the
+    // following targets it should be automatically enabled anyways:
+    #[cfg(not(feature = "force_global_jemalloc"))]
+    check!("linux", "android", "macos", "ios", "freebsd", "netbsd", "openbsd");
+}


### PR DESCRIPTION
This adds a `jemallocator-global` crate that sets `jemallocator` as the `#[global_allocator]` in those platforms in which it is supported and does nothing otherwise. It also comes with a `force` cargo feature that unconditionally sets it as the global allocator. 

It currently does not "conditionally" export any of the `jemallocator` features - I don't know whether doing this is even possible, but those who need more control should just use `jemallocator` directly, it's ok for this library to just be a convenience that gives you `jemallocator` with its default features enabled.

cc @sfackler 