### PR TITLE
Fix shrink_in_place

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,10 +190,30 @@ unsafe impl Alloc for Jemalloc {
         layout: Layout,
         new_size: usize,
     ) -> Result<(), CannotReallocInPlace> {
+        if new_size == layout.size() { return Ok(()); }
         let flags = layout_to_flags(layout.align(), new_size);
-        let shrunk_size = ffi::xallocx(ptr.cast().as_ptr(), new_size, 0, flags);
-        debug_assert!(shrunk_size >= new_size);
-        Ok(())
+        let usable_size = ffi::xallocx(ptr.cast().as_ptr(), new_size, 0, flags);
+        if usable_size < layout.size() {
+            // `shrink_in_place` succeeds if the usable size of the shrunk
+            // allocation is smaller than that of the current allocation (and
+            // therefore, than the originally requested size). This means that:
+            //
+            // * the size-class of the allocation was changed to the size-class
+            // of `new_size`, therefore the allocation can be deallocated with
+            // `new_size`
+            //
+            // * if `new_size` lies in the same size class as `layout.size()`,
+            // and `new_size != layout.size()` then `shrink_in_place` will error
+            // even though technically the allocation can be deallocated
+            // properly with `new_size` - the problem is that `xallocx` will
+            // return `layout.size()` if shrinking failed, and we cannot detect
+            // whether that means that shrinking failed or that `new_size` is
+            // part of the same size-class efficiently.
+            //
+            Ok(())
+        } else {
+            Err(CannotReallocInPlace)
+        }
     }
 }
 

--- a/tests/shrink_in_place.rs
+++ b/tests/shrink_in_place.rs
@@ -27,7 +27,6 @@ fn shrink_in_place() {
             let new_l = Layout::from_size_align(new_sz, 1).unwrap();
             Jemalloc.dealloc(ptr, new_l);
         } else {
-            assert!(false);
             // if shrink in place failed - deallocate with the old layout
             Jemalloc.dealloc(ptr, orig_l);
         }

--- a/tests/shrink_in_place.rs
+++ b/tests/shrink_in_place.rs
@@ -1,0 +1,35 @@
+#![cfg_attr(feature = "alloc_trait", feature(allocator_api))]
+
+extern crate jemallocator;
+
+use jemallocator::Jemalloc;
+
+#[global_allocator]
+static A: Jemalloc = Jemalloc;
+
+#[test]
+#[cfg(feature = "alloc_trait")]
+fn shrink_in_place() {
+    unsafe {
+        use std::alloc::{Alloc, Layout};
+
+        // allocate a "large" block of memory:
+        let orig_sz = 10 * 4096;
+        let orig_l = Layout::from_size_align(orig_sz, 1).unwrap();
+        let ptr = Jemalloc.alloc(orig_l).unwrap();
+
+        // try to shrink it in place to 1 byte - if this succeeds,
+        // the size-class of the new allocation should be different
+        // than that of the original allocation:
+        let new_sz = 1;
+        if let Ok(()) = Jemalloc.shrink_in_place(ptr, orig_l, new_sz) {
+            // test that deallocating with the new layout succeeds:
+            let new_l = Layout::from_size_align(new_sz, 1).unwrap();
+            Jemalloc.dealloc(ptr, new_l);
+        } else {
+            assert!(false);
+            // if shrink in place failed - deallocate with the old layout
+            Jemalloc.dealloc(ptr, orig_l);
+        }
+    }
+}


### PR DESCRIPTION
The current `shrink_in_place` implementation is incorrect. It returns `Ok` if the `usable_size` returned by `xmallocx` is `>= new_size`. 

However, `xmallocx` returns the `usable_size` of the original allocation, which is `>= new_size`, if: 

* the allocation cannot be shrunk in place, e.g., because  `new_size` lands in a different size-class -  we must return error here since `new_size` cannot be used to deallocate the allocation but `Alloc::shrink_in_place` users are allowed to do that on success
* `new_size` is in the same size-class as the original allocation - in which the allocation was shrunk appropriately by zero, and `new_size` can be used to deallocate the allocation since it lands in the same size-class 