### PR TITLE
Fix extent hooks struct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ matrix:
     # TOOLING  
     - name: "Documentation"
       install: pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-      script: cargo doc
+      script: RUSTDOCFLAGS="--cfg jemallocator_docs" cargo doc
       after_success: travis-cargo --only nightly doc-upload
     - name: "rustfmt"
       install: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,7 @@ stats = ["jemalloc-sys/stats"]
 background_threads_runtime_support = ["jemalloc-sys/background_threads_runtime_support"]
 background_threads = ["jemalloc-sys/background_threads"]
 unprefixed_malloc_on_supported_platforms = ["jemalloc-sys/unprefixed_malloc_on_supported_platforms"]
+
+[package.metadata.docs.rs]
+features = [ "alloc_trait" ]
+rustdoc-args = [ "--cfg jemallocator_docs" ]

--- a/jemalloc-sys/Cargo.toml
+++ b/jemalloc-sys/Cargo.toml
@@ -33,3 +33,6 @@ background_threads_runtime_support = []
 background_threads = [ "background_threads_runtime_support" ]
 stats = []
 unprefixed_malloc_on_supported_platforms = []
+
+[package.metadata.docs.rs]
+rustdoc-args = [ "--cfg jemallocator_docs" ]


### PR DESCRIPTION
The fields of the `extent_hooks_s` type were `*mut fn(...)->...`  which are pointers to function pointers, but they should have been function pointers (`Option<fn(...)->...>`) instead. 

`ctest` does not see through type aliases, and needs to know from syntax whether the type inside an `Option` is a `fn` or not to be able to generate the appropriate tests, so this PR duplicates the struct for documentation purposes behind a `--cfg jemallocator_docs` flag, so that the type aliases are properly rendered in the docs. To avoid breaking `docs.rs` we include this in the cargo meta-data.